### PR TITLE
Support headless chrome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
     gem "rspec-#{name}", github: "rspec/rspec-#{name}"
   end
   gem "capybara"
+  gem "selenium-webdriver"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -239,6 +241,7 @@ GEM
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -250,6 +253,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.6.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -321,6 +327,7 @@ DEPENDENCIES
   rspec-rails!
   rspec-support!
   sass-rails (~> 5.0)
+  selenium-webdriver
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,14 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseRewinder.clean
   end
+  config.before(type: :system) do |ex|
+    if ex.metadata[:js]
+      caps = Selenium::WebDriver::Remote::Capabilities.chrome(
+        chromeOptions: { args: %w[--headless] },
+      )
+      driven_by(:selenium, options: { desired_capabilities: caps })
+    else
+      driven_by(:rack_test)
+    end
+  end
 end


### PR DESCRIPTION
Use the headless chrome with `js: true` meta data.
The example is like this: 
```ruby
it "supports the headless chrome", js: true do
  expect(something).to eq true
end
```